### PR TITLE
docs: document configuration via `git config` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ If you have some git repositories (e.g. `~/projects/foo` and `~/projects/bar`) i
 	paths = /Users/you/projects/*
 ```
 
+You can also utilise the `git config` command to configure git-remind to avoid the manually editing of the `.gitconfig`.
+```bash
+git config --global remind.paths /Users/you/projects/*
+```
+
 Check the configuration using following command:
 
 ```bash


### PR DESCRIPTION
Document utilisation of `git config` command for the `git-remind` configuration.